### PR TITLE
feat: Add opacity to bestiole drawing and reduced opacity for camouflage 

### DIFF
--- a/include/accessories/Camouflage.h
+++ b/include/accessories/Camouflage.h
@@ -22,6 +22,7 @@ public:
     return accessories;
   }
   double getCamouflage() const override;
+  double getOpacity() const override;
 
 private:
   double m_psi;

--- a/src/accessories/Camouflage.cpp
+++ b/src/accessories/Camouflage.cpp
@@ -50,3 +50,8 @@ double Camouflage::getCamouflage() const {
   // Override IBestiole's default getCamouflage()
   return m_psi;
 }
+
+double Camouflage::getOpacity() const {
+  // Return a reduced opacity to simulate transparency
+  return 0.3;
+}

--- a/src/core/Bestiole.cpp
+++ b/src/core/Bestiole.cpp
@@ -290,9 +290,9 @@ void Bestiole::draw(UImg &support) {
 
   // Draw the body (ellipse).
   support.draw_ellipse(m_x, m_y, kAffSizePixels, kAffSizePixels / 5.,
-                       -m_orientation / M_PI * 180., drawColor);
+                       -m_orientation / M_PI * 180., drawColor, this->getOpacity());
   // Draw the head (circle).
-  support.draw_circle(headX, headY, kAffSizePixels / 2., drawColor);
+  support.draw_circle(headX, headY, kAffSizePixels / 2., drawColor, this->getOpacity());
 }
 
 /**

--- a/src/core/Bestiole.cpp
+++ b/src/core/Bestiole.cpp
@@ -290,9 +290,11 @@ void Bestiole::draw(UImg &support) {
 
   // Draw the body (ellipse).
   support.draw_ellipse(m_x, m_y, kAffSizePixels, kAffSizePixels / 5.,
-                       -m_orientation / M_PI * 180., drawColor, this->getOpacity());
+                       -m_orientation / M_PI * 180., drawColor,
+                       this->getOpacity());
   // Draw the head (circle).
-  support.draw_circle(headX, headY, kAffSizePixels / 2., drawColor, this->getOpacity());
+  support.draw_circle(headX, headY, kAffSizePixels / 2., drawColor,
+                      this->getOpacity());
 }
 
 /**


### PR DESCRIPTION
Add opacity to bestiole drawing and implement reduced opacity for camouflaged bestioles.

This fixes #24 